### PR TITLE
fix: address zizmor security findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default: 7
     # Only update Wormhole dependencies
     allow:
       - dependency-name: "@wormhole-foundation/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default: 7
+      default-days: 7
     # Only update Wormhole dependencies
     allow:
       - dependency-name: "@wormhole-foundation/*"


### PR DESCRIPTION
## Summary

- **`dependabot-cooldown`** in `.github/dependabot.yml`: Added `cooldown: default: 7` to the npm package ecosystem update entry to satisfy the minimum cooldown configuration requirement.

## Findings Fixed

| Audit | File |
|-------|------|
| `dependabot-cooldown` | `.github/dependabot.yml` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)